### PR TITLE
Uses keys-example.js file

### DIFF
--- a/keys-example.js
+++ b/keys-example.js
@@ -1,3 +1,4 @@
+// use keys.js file
 module.exports = {
     google: {
         clientID: "",


### PR DESCRIPTION
I replaced the keys.js file with keys-example.js 

This should hopefully allow us to avoid problems with .gitignore