### PR TITLE
Fixes no message error, when user clicks "logout", or non-signed in user goes to "/"

### DIFF
--- a/main.js
+++ b/main.js
@@ -82,8 +82,8 @@ app.use(cookieParser());
 
 //landing page
 app.get("/", (req,res) => {
+  var context = {};
   if(req.session.token) {
-    var context = {};
     var emailAddr = req.session.passport.user.profile.emails[0].value;
     if(authorizedEmail(emailAddr)) {
       // TODO: allow customizable projects
@@ -118,7 +118,7 @@ app.get("/", (req,res) => {
       res.render("sign-in", context);
     }
   } else {
-    context.message = "Only users with Oregon State credentials can access VIDE. Sorry.";
+    context.message = "You must log in with an Oregon State email address to use VIDE.";
     res.render("sign-in", context);
   }
 });


### PR DESCRIPTION
Fixes #22 

Also updates the error message, when the user is not signed in at all, to 
"You must log in with an Oregon State email address to use VIDE."