### PR TITLE
Creates ./workspaces directory, if it does not exist

### DIFF
--- a/file-io.js
+++ b/file-io.js
@@ -41,6 +41,11 @@ function writeUserFile(fileName, fileContent, namespace, project) {
 module.exports = {
   // builds directory, if it does not yet exist
   buildProject: function(namespace, project) {
+    // check if main workspace directory exists
+    if (!fs.existsSync(ROOT_SPACE)) {
+      fs.mkdirSync(ROOT_SPACE);
+    }
+
     // var path = projectPath(namespace, project);
     var path = ROOT_SPACE + namespace;
 


### PR DESCRIPTION
Fixes #18 

An error was being thrown if the app started, and this folder did not exist.

This creates the folder, before trying to create a namespace, if it has not yet been created.