### PR TITLE
Added colon to the switch statement on the tutorials

### DIFF
--- a/public/javascript/ide.js
+++ b/public/javascript/ide.js
@@ -831,7 +831,7 @@ $(document).click(function(event) {
 		case "Advanced Tutorial":
 			sendDialogFlow("start advanced tutorial");
 			break;
-		case "Help"
+		case "Help":
 			sendDialogFlow("help");
 			break;
 	}


### PR DESCRIPTION
I missed the colon on one of the tutorials so the page won't load without it. 